### PR TITLE
exit with 1 if result is suspicious

### DIFF
--- a/minesweeper.go
+++ b/minesweeper.go
@@ -320,4 +320,8 @@ func main() {
 	if !ok || options.Verbose {
 		fmt.Printf("%s\n", report)
 	}
+
+	if !ok {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
Seems like it might be useful to exit with a result other than 0 if the result is suspicious.
